### PR TITLE
Try using wpProject for image nodeType

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -116,7 +116,7 @@ module.exports = {
     {
       resolve: `gatsby-plugin-remote-images`,
       options: {
-        nodeType: "WpProject",
+        nodeType: "wpProject",
         imagePath: "featuredImage.node.sourceUrl",
       },
     },


### PR DESCRIPTION
Was getting error:
error gatsby-plugin-remote-images ERROR: url passed to createRemoteFileNode is
either missing or not a proper web uri: undefined